### PR TITLE
Enable MSVC workflow for Windows builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,41 +63,38 @@ jobs:
           shell: msys2 {0}
           run: meson test -C builddir || cat builddir\meson-logs\testlog.txt
 
-  # https://github.com/andy5995/canfigger/issues/31
-  #VisualStudio:
-    #runs-on: windows-latest
-    #strategy:
-      #fail-fast: false
-      #matrix:
-        #platform: ['x64', 'x86']
-    #steps:
-      #- uses: actions/checkout@v6
+  VisualStudio:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ['x64', 'x86']
+    steps:
+      - uses: actions/checkout@v6
 
-      ## Install a 32-bit Python so building related stuff work.
-      #- name: Setup x86 Python
-        #if: matrix.platform == 'x86'
-        #uses: actions/setup-python@v5
-        #with:
-          #architecture: 'x86'
-          #python-version: '3.12'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          architecture: ${{ matrix.platform == 'x86' && 'x86' || 'x64' }}
+          python-version: '3.12'
 
-      ## https://github.com/actions/runner-images/issues/5459#issuecomment-1532856844
-      #- name: Remove bad Strawberry Perl patch binary in search path
-        #run: del C:\Strawberry\c\bin\patch.EXE
+      - name: Remove bad Strawberry Perl patch binary in search path
+        run: del C:\Strawberry\c\bin\patch.EXE
+        continue-on-error: true
 
-      #- name: Install packages
-        #run: |
-          #python -m pip install --pre meson
+      - name: Install meson
+        run: |
+          python -m pip install --pre meson
 
-      #- uses: ilammy/msvc-dev-cmd@v1
-        #with:
-          #arch: ${{matrix.platform}}
-      #- name: Configure
-        #run: meson setup builddir -Ddefault_library=static -Db_sanitize=none
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.platform}}
 
-      #- name: Build
-        #run: meson compile -C builddir
+      - name: Configure
+        run: meson setup builddir -Ddefault_library=static -Db_sanitize=none
 
-      #- name: Test
-        #run: |
-          #meson test -C builddir || cat builddir\meson-logs\testlog.txt
+      - name: Build
+        run: meson compile -C builddir
+
+      - name: Test
+        run: meson test -C builddir --verbose || (if exist builddir\meson-logs\testlog.txt type builddir\meson-logs\testlog.txt)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -97,4 +97,5 @@ jobs:
         run: meson compile -C builddir
 
       - name: Test
+        shell: cmd
         run: meson test -C builddir --verbose || (if exist builddir\meson-logs\testlog.txt type builddir\meson-logs\testlog.txt)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,4 +98,6 @@ jobs:
 
       - name: Test
         shell: cmd
-        run: meson test -C builddir --verbose || (if exist builddir\meson-logs\testlog.txt type builddir\meson-logs\testlog.txt)
+        env:
+          PYTHONUTF8: 1
+        run: meson test --no-stdsplit -v -C builddir || (if exist builddir\meson-logs\testlog.txt type builddir\meson-logs\testlog.txt)

--- a/canfigger.c
+++ b/canfigger.c
@@ -401,19 +401,24 @@ canfigger_parse_file(const char *file, const int delimiter)
     while (isspace(*line_ptr))
       line_ptr = erase_lead_char(*line_ptr, line_ptr);
 
-    if (*line_ptr == '\0' || *line_ptr == '#' || *line_ptr == '[')
+    if (*line_ptr == '\0' || *line_ptr == '#' || *line_ptr == '[') {
+      free(tmp_line);
       continue;
+    }
 
     node_complete = false;
     add_key_node(&root, &cur_node);
-    if (!cur_node)
+    if (!cur_node) {
+      free(tmp_line);
       break;
+    }
 
     // Get key
     cur_node->key = NULL;
     line_ptr = grab_str_segment(line_ptr, &cur_node->key, '=');
     if (!cur_node->key)
     {
+      free(tmp_line);
       free_incomplete_node(&cur_node);
       break;
     }
@@ -426,6 +431,7 @@ canfigger_parse_file(const char *file, const int delimiter)
       line_ptr = grab_str_segment(line_ptr, &cur_node->value, delimiter);
       if (!cur_node->value)
       {
+        free(tmp_line);
         free_incomplete_node(&cur_node);
         break;
       }
@@ -437,6 +443,7 @@ canfigger_parse_file(const char *file, const int delimiter)
       cur_node->attributes = malloc_wrap(sizeof(struct attributes));
       if (!cur_node->attributes)
       {
+        free(tmp_line);
         free_incomplete_node(&cur_node);
         break;
       }
@@ -447,6 +454,7 @@ canfigger_parse_file(const char *file, const int delimiter)
       attr_ptr->str = strclone(line_ptr, 0);
       if (!attr_ptr->str)
       {
+        free(tmp_line);
         free_incomplete_node(&cur_node);
         break;
       }

--- a/canfigger.c
+++ b/canfigger.c
@@ -361,8 +361,13 @@ canfigger_parse_file(const char *file, const int delimiter)
   if (buffer == NULL)
     return NULL;
 
-  char file_contents[strlen(buffer) + 1];
-  memcpy(file_contents, buffer, sizeof file_contents);
+  size_t buffer_len = strlen(buffer) + 1;
+  char *file_contents = malloc_wrap(buffer_len);
+  if (!file_contents) {
+    free(buffer);
+    return NULL;
+  }
+  memcpy(file_contents, buffer, buffer_len);
   free(buffer);
 
   struct line line;
@@ -374,7 +379,11 @@ canfigger_parse_file(const char *file, const int delimiter)
   while (line.end)
   {
     line.len = line.end - line.start;
-    char tmp_line[line.len + 1];
+    char *tmp_line = malloc_wrap(line.len + 1);
+    if (!tmp_line) {
+      free(file_contents);
+      return NULL;
+    }
 
     memcpy(tmp_line, line.start, line.len);
     tmp_line[line.len] = '\0';
@@ -458,16 +467,21 @@ canfigger_parse_file(const char *file, const int delimiter)
 
     cur_node->next = NULL;
     node_complete = true;
+    free(tmp_line);
   }
 
-  if (!root)
+  if (!root) {
+    free(file_contents);
     return NULL;
+  }
 
   if (!node_complete)
   {
+    free(file_contents);
     canfigger_free_list(&root);
     return NULL;
   }
 
+  free(file_contents);
   return root;
 }

--- a/example-02.c
+++ b/example-02.c
@@ -17,7 +17,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#ifdef _MSC_VER
+  #define strcasecmp _stricmp
+#else
+  #include <strings.h>
+#endif
 
 typedef enum {
   CFG_TYPE_STRING,

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,11 @@ extra_flags = [
 
 add_project_arguments(cc.get_supported_arguments(extra_flags), language: 'c')
 
+# Suppress MSVC C4996 deprecation warnings for standard C functions like strerror()
+if cc.get_id() == 'msvc'
+  add_project_arguments('/D_CRT_SECURE_NO_WARNINGS', language: 'c')
+endif
+
 # Parse version components
 version_components = meson.project_version().split('.')
 major_version = version_components[0]


### PR DESCRIPTION
- Uncomment and update VisualStudio job in windows.yml
- Use conditional matrix logic for Python architecture (x86 vs x64)
- Add continue-on-error for Perl patch cleanup (may not exist)
- Improve test error handling with proper Windows path syntax
- Use --verbose flag for better test output