### PR TITLE
Add canfigger_config_file()

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,8 @@
 - (in-progress)
 
+  + Add canfigger_config_file(): returns $XDG_CONFIG_HOME/filename or
+    $HOME/.config/filename, for config files that live directly under the
+    config root rather than in a per-application subdirectory
   * Headers are now installed to /usr/include/canfigger/; the pkgconfig
     Cflags is updated accordingly so #include <canfigger.h> continues to
     work without changes

--- a/README.md
+++ b/README.md
@@ -40,10 +40,22 @@ argument:
 
 ## Platform path helpers
 
-Canfigger also provides `canfigger_config_dir()`, `canfigger_data_dir()`, and
-`canfigger_path_join()` for locating the standard per-user config and data
-directories on Linux (XDG), macOS, and Windows. See the API documentation for
-details.
+Canfigger provides helpers for locating standard per-user paths on Linux
+(XDG), macOS, and Windows:
+
+- `canfigger_config_dir(appname)` — returns the per-application config
+  directory (`$XDG_CONFIG_HOME/appname` or `$HOME/.config/appname`)
+- `canfigger_data_dir(appname)` — returns the per-application data
+  directory (`$XDG_DATA_HOME/appname` or `$HOME/.local/share/appname`)
+- `canfigger_config_file(filename)` — returns a path directly under the
+  base config directory, without an application subdirectory
+  (`$XDG_CONFIG_HOME/filename` or `$HOME/.config/filename`); useful when
+  the config file lives at the config root rather than in a per-application
+  subdirectory
+- `canfigger_path_join(dir, file)` — joins a directory and filename with
+  the platform separator
+
+See the API documentation for details.
 
 ## Dependencies
 

--- a/canfigger.c
+++ b/canfigger.c
@@ -216,7 +216,7 @@ truncate_whitespace(char *str)
   else
     return;
 
-  while (isspace((unsigned char)*str))
+  while (isspace((unsigned char) *str))
   {
     *str = '\0';
     if (str != pos_0)
@@ -290,13 +290,16 @@ read_entire_file(const char *filename)
   FILE *fp = fopen(filename, "rb");
   if (!fp)
   {
-    fprintf(stderr, "canfigger: Failed to open %s: %s\n", filename, strerror(errno));
+    fprintf(stderr, "canfigger: Failed to open %s: %s\n", filename,
+            strerror(errno));
     return NULL;
   }
 
-  if (fseek(fp, 0, SEEK_END) != 0 || (file_size = ftell(fp)) < 0 || fseek(fp, 0, SEEK_SET) != 0)
+  if (fseek(fp, 0, SEEK_END) != 0 || (file_size = ftell(fp)) < 0
+      || fseek(fp, 0, SEEK_SET) != 0)
   {
-    fprintf(stderr, "canfigger: Failed to determine size of %s: %s\n", filename, strerror(errno));
+    fprintf(stderr, "canfigger: Failed to determine size of %s: %s\n",
+            filename, strerror(errno));
     goto done;
   }
 
@@ -308,9 +311,11 @@ read_entire_file(const char *filename)
   if (n_bytes != (size_t) file_size)
   {
     if (ferror(fp))
-      fprintf(stderr, "canfigger: Error reading %s: %s\n", filename, strerror(errno));
+      fprintf(stderr, "canfigger: Error reading %s: %s\n", filename,
+              strerror(errno));
     else
-      fprintf(stderr, "canfigger: Partial read of %s: expected %ld bytes, got %zu bytes\n",
+      fprintf(stderr,
+              "canfigger: Partial read of %s: expected %ld bytes, got %zu bytes\n",
               filename, file_size, n_bytes);
     free(buffer);
     buffer = NULL;
@@ -364,9 +369,9 @@ canfigger_parse_file(const char *file, const int delimiter)
    * matched 0xEF (so at least 1 file byte exists), and [2] only when [1]
    * matched 0xBB (so at least 2 exist). */
   char *parse_start = file_contents;
-  if ((unsigned char)parse_start[0] == 0xEF &&
-      (unsigned char)parse_start[1] == 0xBB &&
-      (unsigned char)parse_start[2] == 0xBF)
+  if ((unsigned char) parse_start[0] == 0xEF &&
+      (unsigned char) parse_start[1] == 0xBB &&
+      (unsigned char) parse_start[2] == 0xBF)
     parse_start += 3;
 
   struct line line;
@@ -377,14 +382,16 @@ canfigger_parse_file(const char *file, const int delimiter)
   for (;;)
   {
     line.end = strchr(line.start, '\n');
-    line.len = line.end ? (size_t)(line.end - line.start) : strlen(line.start);
+    line.len =
+      line.end ? (size_t) (line.end - line.start) : strlen(line.start);
 
     /* End of file with no remaining content */
     if (line.len == 0 && !line.end)
       break;
 
     char *tmp_line = malloc_wrap(line.len + 1);
-    if (!tmp_line) {
+    if (!tmp_line)
+    {
       canfigger_free_list(&root);
       free(file_contents);
       return NULL;
@@ -397,10 +404,11 @@ canfigger_parse_file(const char *file, const int delimiter)
     char *line_ptr = tmp_line;
     truncate_whitespace(line_ptr);
 
-    while (isspace((unsigned char)*line_ptr))
+    while (isspace((unsigned char) *line_ptr))
       line_ptr = erase_lead_char(*line_ptr, line_ptr);
 
-    if (*line_ptr == '\0' || *line_ptr == '#' || *line_ptr == '[') {
+    if (*line_ptr == '\0' || *line_ptr == '#' || *line_ptr == '[')
+    {
       free(tmp_line);
       if (!line.end)
         break;
@@ -410,7 +418,8 @@ canfigger_parse_file(const char *file, const int delimiter)
     node_complete = false;
     struct Canfigger *prev_node = cur_node;
     add_key_node(&root, &cur_node);
-    if (cur_node == prev_node) {
+    if (cur_node == prev_node)
+    {
       free(tmp_line);
       break;
     }
@@ -482,7 +491,8 @@ canfigger_parse_file(const char *file, const int delimiter)
       break;
   }
 
-  if (!root) {
+  if (!root)
+  {
     free(file_contents);
     return NULL;
   }
@@ -519,7 +529,8 @@ dir_for_appname(const char *appname, int csidl)
 }
 #else
 static char *
-dir_for_appname(const char *appname, const char *xdg_env, const char *xdg_fallback)
+dir_for_appname(const char *appname, const char *xdg_env,
+                const char *xdg_fallback)
 {
   if (!appname || *appname == '\0')
     return NULL;
@@ -539,7 +550,8 @@ dir_for_appname(const char *appname, const char *xdg_env, const char *xdg_fallba
   if (!home || !*home)
     return NULL;
 
-  size_t len = strlen(home) + 1 + strlen(xdg_fallback) + 1 + strlen(appname) + 1;
+  size_t len =
+    strlen(home) + 1 + strlen(xdg_fallback) + 1 + strlen(appname) + 1;
   char *result = malloc_wrap(len);
   if (!result)
     return NULL;
@@ -556,6 +568,49 @@ canfigger_config_dir(const char *appname)
   return dir_for_appname(appname, CSIDL_APPDATA);
 #else
   return dir_for_appname(appname, "XDG_CONFIG_HOME", ".config");
+#endif
+}
+
+
+char *
+canfigger_config_file(const char *filename)
+{
+  if (!filename || !*filename)
+    return NULL;
+
+#ifdef _WIN32
+  char base[MAX_PATH];
+  if (FAILED(SHGetFolderPathA(NULL, CSIDL_APPDATA, NULL, 0, base)))
+    return NULL;
+
+  size_t len = strlen(base) + 1 + strlen(filename) + 1;
+  char *result = malloc_wrap(len);
+  if (!result)
+    return NULL;
+  snprintf(result, len, "%s\\%s", base, filename);
+  return result;
+#else
+  const char *base = getenv("XDG_CONFIG_HOME");
+  if (base && *base)
+  {
+    size_t len = strlen(base) + 1 + strlen(filename) + 1;
+    char *result = malloc_wrap(len);
+    if (!result)
+      return NULL;
+    snprintf(result, len, "%s/%s", base, filename);
+    return result;
+  }
+
+  const char *home = getenv("HOME");
+  if (!home || !*home)
+    return NULL;
+
+  size_t len = strlen(home) + strlen("/.config/") + strlen(filename) + 1;
+  char *result = malloc_wrap(len);
+  if (!result)
+    return NULL;
+  snprintf(result, len, "%s/.config/%s", home, filename);
+  return result;
 #endif
 }
 
@@ -579,7 +634,8 @@ canfigger_path_join(const char *dir, const char *file)
 
   size_t dirlen = strlen(dir);
   size_t filelen = strlen(file);
-  bool needs_sep = dirlen > 0 && dir[dirlen - 1] != '/' && dir[dirlen - 1] != '\\';
+  bool needs_sep = dirlen > 0 && dir[dirlen - 1] != '/'
+    && dir[dirlen - 1] != '\\';
   size_t total = dirlen + (needs_sep ? 1 : 0) + filelen + 1;
 
   char *result = malloc_wrap(total);

--- a/canfigger.h
+++ b/canfigger.h
@@ -82,7 +82,8 @@ SOFTWARE.
    (CANFIGGER_VERSION_MAJOR == (maj) && CANFIGGER_VERSION_MINOR >= (min)))
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /**
@@ -100,12 +101,12 @@ extern "C" {
  * @var attributes::iter_ptr Read position within @p str; advanced by each
  *                           call to canfigger_free_current_attr_str_advance().
  */
-struct attributes
-{
-  char *str;
-  char *current;
-  char *iter_ptr;
-};
+  struct attributes
+  {
+    char *str;
+    char *current;
+    char *iter_ptr;
+  };
 
 /**
  * @struct Canfigger
@@ -122,13 +123,13 @@ struct attributes
  *                            attributes following the value.
  * @var Canfigger::next       Next node, or NULL at end of list.
  */
-struct Canfigger
-{
-  char *key;
-  char *value;
-  struct attributes *attributes;
-  struct Canfigger *next;
-};
+  struct Canfigger
+  {
+    char *key;
+    char *value;
+    struct attributes *attributes;
+    struct Canfigger *next;
+  };
 
 /**
  * @brief Parse a configuration file into a linked list of key-value nodes.
@@ -150,7 +151,8 @@ struct Canfigger
  * @return Head of the linked list, or NULL if the file cannot be opened,
  *         is empty, or a memory allocation failure occurs.
  */
-struct Canfigger *canfigger_parse_file(const char *file, const int delimiter);
+  struct Canfigger *canfigger_parse_file(const char *file,
+                                         const int delimiter);
 
 /**
  * @brief Free the current node and advance the list pointer to the next node.
@@ -167,7 +169,7 @@ struct Canfigger *canfigger_parse_file(const char *file, const int delimiter);
  * @param node Double pointer to the current node; updated to point to the
  *             next node (or NULL at end of list) before returning.
  */
-void canfigger_free_current_key_node_advance(struct Canfigger **node);
+  void canfigger_free_current_key_node_advance(struct Canfigger **node);
 
 /**
  * @brief Free the current attribute string and advance to the next attribute.
@@ -192,7 +194,8 @@ void canfigger_free_current_key_node_advance(struct Canfigger **node);
  * @param attr       Output parameter; set to the next attribute string on
  *                   success, or NULL when the list is exhausted.
  */
-void canfigger_free_current_attr_str_advance(struct attributes *attributes, char **attr);
+  void canfigger_free_current_attr_str_advance(struct attributes *attributes,
+                                               char **attr);
 
 /**
  * @brief Free all remaining nodes in the list.
@@ -204,7 +207,7 @@ void canfigger_free_current_attr_str_advance(struct attributes *attributes, char
  * @param node Double pointer to the current (or head) node; set to NULL
  *             on return.
  */
-void canfigger_free_list(struct Canfigger **node);
+  void canfigger_free_list(struct Canfigger **node);
 
 /**
  * @brief Return the platform config directory for an application.
@@ -218,7 +221,27 @@ void canfigger_free_list(struct Canfigger **node);
  * @return Malloc'd path string, or NULL on failure or if @p appname is
  *         NULL/empty.
  */
-char *canfigger_config_dir(const char *appname);
+  char *canfigger_config_dir(const char *appname);
+
+/**
+ * @brief Return the path to a config file in the platform base config directory.
+ *
+ * Joins the base config directory with @p filename, without inserting an
+ * application-name subdirectory.  On Unix, honours @c $XDG_CONFIG_HOME if
+ * set; otherwise uses @c $HOME/.config/filename.  On Windows, uses
+ * @c %APPDATA%\\filename.
+ *
+ * Use this when the config file lives directly under the config root rather
+ * than in a per-application subdirectory (e.g. @c $HOME/.config/apprc rather
+ * than @c $HOME/.config/app/apprc).
+ *
+ * The returned string is heap-allocated; the caller must free it.
+ *
+ * @param filename Config file name (or relative sub-path) to append.
+ * @return Malloc'd path string, or NULL on failure or if @p filename is
+ *         NULL or empty.
+ */
+  char *canfigger_config_file(const char *filename);
 
 /**
  * @brief Return the platform data directory for an application.
@@ -234,7 +257,7 @@ char *canfigger_config_dir(const char *appname);
  * @return Malloc'd path string, or NULL on failure or if @p appname is
  *         NULL/empty.
  */
-char *canfigger_data_dir(const char *appname);
+  char *canfigger_data_dir(const char *appname);
 
 /**
  * @brief Join a directory path and a filename with the platform separator.
@@ -249,7 +272,7 @@ char *canfigger_data_dir(const char *appname);
  * @return Malloc'd joined path string, or NULL if either argument is NULL or
  *         empty, or on allocation failure.
  */
-char *canfigger_path_join(const char *dir, const char *file);
+  char *canfigger_path_join(const char *dir, const char *file);
 
 #ifdef __cplusplus
 }

--- a/tests/config_file.c
+++ b/tests/config_file.c
@@ -1,0 +1,53 @@
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 200112L
+#endif
+
+#include "tests/test.h"
+
+#ifdef _WIN32
+static void
+test_config_file(void)
+{
+  char *path;
+
+  path = canfigger_config_file("app.conf");
+  assert(path != NULL);
+  assert(strstr(path, "app.conf") != NULL);
+  free(path);
+
+  assert(canfigger_config_file(NULL) == NULL);
+  assert(canfigger_config_file("") == NULL);
+}
+#else
+static void
+test_config_file(void)
+{
+  char *path;
+
+  // XDG_CONFIG_HOME set
+  setenv("XDG_CONFIG_HOME", "/tmp/testcfg", 1);
+  path = canfigger_config_file("app.conf");
+  assert(path != NULL);
+  assert(strcmp(path, "/tmp/testcfg/app.conf") == 0);
+  free(path);
+  unsetenv("XDG_CONFIG_HOME");
+
+  // XDG_CONFIG_HOME unset: fall back to $HOME/.config
+  setenv("HOME", "/tmp/testhome", 1);
+  path = canfigger_config_file("app.conf");
+  assert(path != NULL);
+  assert(strcmp(path, "/tmp/testhome/.config/app.conf") == 0);
+  free(path);
+
+  // NULL / empty guards
+  assert(canfigger_config_file(NULL) == NULL);
+  assert(canfigger_config_file("") == NULL);
+}
+#endif
+
+int
+main(void)
+{
+  test_config_file();
+  return 0;
+}

--- a/tests/dirs.c
+++ b/tests/dirs.c
@@ -3,8 +3,6 @@
 #endif
 
 #include "tests/test.h"
-#include <stdlib.h>
-#include <string.h>
 
 static void
 test_path_join(void)
@@ -12,15 +10,21 @@ test_path_join(void)
   char *path;
 
 #ifdef _WIN32
-  path = canfigger_path_join("C:\\Users\\user\\AppData\\Roaming\\app", "settings.conf");
+  path =
+    canfigger_path_join("C:\\Users\\user\\AppData\\Roaming\\app",
+                        "settings.conf");
   assert(path != NULL);
-  assert(strcmp(path, "C:\\Users\\user\\AppData\\Roaming\\app\\settings.conf") == 0);
+  assert(strcmp(path, "C:\\Users\\user\\AppData\\Roaming\\app\\settings.conf")
+         == 0);
   free(path);
 
   // Trailing separator: no double backslash
-  path = canfigger_path_join("C:\\Users\\user\\AppData\\Roaming\\app\\", "settings.conf");
+  path =
+    canfigger_path_join("C:\\Users\\user\\AppData\\Roaming\\app\\",
+                        "settings.conf");
   assert(path != NULL);
-  assert(strcmp(path, "C:\\Users\\user\\AppData\\Roaming\\app\\settings.conf") == 0);
+  assert(strcmp(path, "C:\\Users\\user\\AppData\\Roaming\\app\\settings.conf")
+         == 0);
   free(path);
 #else
   path = canfigger_path_join("/home/user/.config/app", "settings.conf");

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,6 +2,7 @@ test_cases = [
   'check_version',
   'bom',
   'colons',
+  'config_file',
   'dirs',
   'file_open_err',
   'german',

--- a/tests/test.h
+++ b/tests/test.h
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include <canfigger.h>


### PR DESCRIPTION
Returns $XDG_CONFIG_HOME/filename or $HOME/.local/share/filename for config files that live directly under the config root rather than in a per-application subdirectory.