### PR TITLE
Add canfigger_get_int_attrs() and canfigger_get_double_attrs()

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,8 @@
 (in-progress):
 
 * Doxyfile: Exclude tests (remove unused structs from docs)
+  + Add canfigger_get_int_attrs(): parse node attributes as an int array
+  + Add canfigger_get_double_attrs(): parse node attributes as a double array
 
 2026-05-11
 

--- a/canfigger.c
+++ b/canfigger.c
@@ -509,6 +509,85 @@ canfigger_parse_file(const char *file, const int delimiter)
 }
 
 
+size_t
+canfigger_get_int_attrs(const struct Canfigger *node, int *out, size_t max)
+{
+  if (!node || !node->attributes || !node->attributes->str || !out || !max)
+    return 0;
+
+  size_t count = 0;
+  char *p = node->attributes->str;
+
+  while (count < max)
+  {
+    while (*p == ' ' || *p == '\t')
+      p++;
+
+    if (*p == '\0' || *p == '\n')
+      break;
+
+    char *endptr;
+    errno = 0;
+    long val = strtol(p, &endptr, 10);
+    if (endptr == p || errno == ERANGE)
+      break;
+    out[count++] = (int) val;
+
+    p = endptr;
+    while (*p == ' ' || *p == '\t')
+      p++;
+
+    if (*p == '\0')
+      break;
+    if (*p != '\n')
+      break;
+    p++;
+  }
+
+  return count;
+}
+
+
+size_t
+canfigger_get_double_attrs(const struct Canfigger *node, double *out,
+                           size_t max)
+{
+  if (!node || !node->attributes || !node->attributes->str || !out || !max)
+    return 0;
+
+  size_t count = 0;
+  char *p = node->attributes->str;
+
+  while (count < max)
+  {
+    while (*p == ' ' || *p == '\t')
+      p++;
+
+    if (*p == '\0' || *p == '\n')
+      break;
+
+    char *endptr;
+    errno = 0;
+    double val = strtod(p, &endptr);
+    if (endptr == p || errno == ERANGE)
+      break;
+    out[count++] = val;
+
+    p = endptr;
+    while (*p == ' ' || *p == '\t')
+      p++;
+
+    if (*p == '\0')
+      break;
+    if (*p != '\n')
+      break;
+    p++;
+  }
+
+  return count;
+}
+
+
 #ifndef _WIN32
 static char *
 xdg_base_dir(const char *xdg_env, const char *fallback)

--- a/canfigger.h
+++ b/canfigger.h
@@ -59,6 +59,7 @@ SOFTWARE.
 
 #pragma once
 
+#include <stddef.h>
 #include "canfigger_version.h"
 
 /**
@@ -221,15 +222,7 @@ extern "C"
  * @return Malloc'd path string, or NULL on failure or if @p appname is
  *         NULL/empty.
  *
- * @code
- * char *dir = canfigger_config_dir("myapp");
- * if (dir) {
- *     char *path = canfigger_path_join(dir, "settings.conf");
- *     free(dir);
- *     // open path ...
- *     free(path);
- * }
- * @endcode
+ * @snippet examples/canfigger_config_dir.c canfigger_config_dir
  */
   char *canfigger_config_dir(const char *appname);
 
@@ -251,14 +244,7 @@ extern "C"
  * @return Malloc'd path string, or NULL on failure or if @p filename is
  *         NULL or empty.
  *
- * @code
- * char *path = canfigger_config_file("apprc");
- * if (path) {
- *     struct Canfigger *list = canfigger_parse_file(path, ',');
- *     free(path);
- *     // use list ...
- * }
- * @endcode
+ * @snippet examples/canfigger_config_file.c canfigger_config_file
  */
   char *canfigger_config_file(const char *filename);
 
@@ -305,16 +291,49 @@ extern "C"
  * @return Malloc'd joined path string, or NULL if either argument is NULL or
  *         empty, or on allocation failure.
  *
- * @code
- * char *path = canfigger_path_join("/home/user/.config/myapp", "settings.conf");
- * if (path) {
- *     struct Canfigger *list = canfigger_parse_file(path, ',');
- *     free(path);
- *     // use list ...
- * }
- * @endcode
+ * @snippet examples/canfigger_path_join.c canfigger_path_join
  */
   char *canfigger_path_join(const char *dir, const char *file);
+
+/**
+ * @brief Parse a node's attributes as an array of integers.
+ *
+ * Reads the comma-separated (or user-delimited) attributes following a value
+ * and fills @p out with up to @p max integer values parsed via strtol().
+ * Stops at the first attribute that cannot be parsed as an integer, or when
+ * @p max is reached.
+ *
+ * This accessor is independent of canfigger_free_current_attr_str_advance():
+ * it reads from the beginning of the attribute string and does not advance
+ * or free the string iterator.
+ *
+ * @param node  Node whose attributes are to be parsed (may be NULL).
+ * @param out   Output array; must have room for at least @p max elements.
+ * @param max   Maximum number of integers to store.
+ * @return      Number of integers actually parsed; 0 if @p node has no
+ *              attributes or arguments are invalid.
+ *
+ * @snippet examples/canfigger_get_int_attrs.c canfigger_get_int_attrs
+ */
+  size_t canfigger_get_int_attrs(const struct Canfigger *node, int *out,
+                                 size_t max);
+
+/**
+ * @brief Parse a node's attributes as an array of doubles.
+ *
+ * Like canfigger_get_int_attrs() but parses each attribute as a
+ * floating-point value using strtod().
+ *
+ * @param node  Node whose attributes are to be parsed (may be NULL).
+ * @param out   Output array; must have room for at least @p max elements.
+ * @param max   Maximum number of values to store.
+ * @return      Number of values actually parsed; 0 if @p node has no
+ *              attributes or arguments are invalid.
+ *
+ * @snippet examples/canfigger_get_double_attrs.c canfigger_get_double_attrs
+ */
+  size_t canfigger_get_double_attrs(const struct Canfigger *node, double *out,
+                                    size_t max);
 
 #ifdef __cplusplus
 }

--- a/examples/canfigger_config_dir.c
+++ b/examples/canfigger_config_dir.c
@@ -1,0 +1,32 @@
+/*
+ * Compilable example for canfigger_config_dir().
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "canfigger.h"
+
+static void
+example(void)
+{
+//! [canfigger_config_dir]
+  char *dir = canfigger_config_dir("myapp");
+  if (dir)
+  {
+    char *path = canfigger_path_join(dir, "settings.conf");
+    free(dir);
+    if (path)
+    {
+      struct Canfigger *list = canfigger_parse_file(path, ',');
+      free(path);
+      canfigger_free_list(&list);
+    }
+  }
+//! [canfigger_config_dir]
+}
+
+int
+main(void)
+{
+  example();
+  return 0;
+}

--- a/examples/canfigger_config_file.c
+++ b/examples/canfigger_config_file.c
@@ -1,0 +1,26 @@
+/*
+ * Compilable example for canfigger_config_file().
+ */
+#include <stdlib.h>
+#include "canfigger.h"
+
+static void
+example(void)
+{
+//! [canfigger_config_file]
+  char *path = canfigger_config_file("apprc");
+  if (path)
+  {
+    struct Canfigger *list = canfigger_parse_file(path, ',');
+    free(path);
+    canfigger_free_list(&list);
+  }
+//! [canfigger_config_file]
+}
+
+int
+main(void)
+{
+  example();
+  return 0;
+}

--- a/examples/canfigger_get_double_attrs.c
+++ b/examples/canfigger_get_double_attrs.c
@@ -1,0 +1,35 @@
+/*
+ * Compilable example for canfigger_get_double_attrs().
+ * Config line: scale = factors, 1.0, 0.75, 2.5
+ */
+#include <stdio.h>
+#include <string.h>
+#include "canfigger.h"
+
+static void
+example(struct Canfigger *node)
+{
+//! [canfigger_get_double_attrs]
+  /* Check the value tag, then validate the count before using the array. */
+  if (node->value && strcmp(node->value, "factors") == 0)
+  {
+    double v[3];
+    if (canfigger_get_double_attrs(node, v, 3) == 3)
+    {
+      fprintf(stderr, "factors: %g %g %g\n", v[0], v[1], v[2]);
+    }
+  }
+//! [canfigger_get_double_attrs]
+}
+
+int
+main(void)
+{
+  struct Canfigger *list = canfigger_parse_file("scale.conf", ',');
+  if (list)
+  {
+    example(list);
+    canfigger_free_list(&list);
+  }
+  return 0;
+}

--- a/examples/canfigger_get_int_attrs.c
+++ b/examples/canfigger_get_int_attrs.c
@@ -1,0 +1,36 @@
+/*
+ * Compilable example for canfigger_get_int_attrs().
+ * Config line: board = rect, 10, 20, 640, 480
+ */
+#include <stdio.h>
+#include <string.h>
+#include "canfigger.h"
+
+static void
+example(struct Canfigger *node)
+{
+//! [canfigger_get_int_attrs]
+  /* Check the value tag, then validate the count before using the array. */
+  if (node->value && strcmp(node->value, "rect") == 0)
+  {
+    int v[4];
+    if (canfigger_get_int_attrs(node, v, 4) == 4)
+    {
+      int x = v[0], y = v[1], w = v[2], h = v[3];
+      fprintf(stderr, "rect: x=%d y=%d w=%d h=%d\n", x, y, w, h);
+    }
+  }
+//! [canfigger_get_int_attrs]
+}
+
+int
+main(void)
+{
+  struct Canfigger *list = canfigger_parse_file("board.conf", ',');
+  if (list)
+  {
+    example(list);
+    canfigger_free_list(&list);
+  }
+  return 0;
+}

--- a/examples/canfigger_path_join.c
+++ b/examples/canfigger_path_join.c
@@ -1,0 +1,27 @@
+/*
+ * Compilable example for canfigger_path_join().
+ */
+#include <stdlib.h>
+#include "canfigger.h"
+
+static void
+example(void)
+{
+//! [canfigger_path_join]
+  char *path =
+    canfigger_path_join("/home/user/.config/myapp", "settings.conf");
+  if (path)
+  {
+    struct Canfigger *list = canfigger_parse_file(path, ',');
+    free(path);
+    canfigger_free_list(&list);
+  }
+//! [canfigger_path_join]
+}
+
+int
+main(void)
+{
+  example();
+  return 0;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,16 @@
+snippet_examples = [
+  'canfigger_config_dir',
+  'canfigger_config_file',
+  'canfigger_path_join',
+  'canfigger_get_int_attrs',
+  'canfigger_get_double_attrs',
+]
+
+foreach ex : snippet_examples
+  executable(
+    'example_' + ex,
+    ex + '.c',
+    dependencies: canfigger_dep,
+    install: false,
+  )
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ if not meson.is_subproject()
         test('test_' + ex, example)
       endif
     endforeach
+    subdir('examples')
   endif
 
   pkg = import('pkgconfig')

--- a/tests/double_attrs.c
+++ b/tests/double_attrs.c
@@ -1,0 +1,38 @@
+#include "test.h"
+
+int
+main(void)
+{
+  struct Canfigger *list =
+    canfigger_parse_file(SOURCE_DIR "/double_attrs.conf", ',');
+  assert(list);
+
+  /* scale = factors, 1.5, 2.0, 0.75 */
+  assert(strcmp(list->key, "scale") == 0);
+  assert(strcmp(list->value, "factors") == 0);
+  double factors[3];
+  size_t n = canfigger_get_double_attrs(list, factors, 3);
+  assert(n == 3);
+  assert(factors[0] == 1.5);
+  assert(factors[1] == 2.0);
+  assert(factors[2] == 0.75);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* point = pos, 10.5, 20.0 — max less than attribute count */
+  assert(strcmp(list->key, "point") == 0);
+  double pt[1];
+  n = canfigger_get_double_attrs(list, pt, 1);
+  assert(n == 1);
+  assert(pt[0] == 10.5);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* noattrs = plain — no attributes, expect 0 */
+  assert(strcmp(list->key, "noattrs") == 0);
+  double dummy[1];
+  n = canfigger_get_double_attrs(list, dummy, 1);
+  assert(n == 0);
+  canfigger_free_current_key_node_advance(&list);
+
+  assert(list == NULL);
+  return 0;
+}

--- a/tests/double_attrs.conf
+++ b/tests/double_attrs.conf
@@ -1,0 +1,3 @@
+scale = factors, 1.5, 2.0, 0.75
+point = pos, 10.5, 20.0
+noattrs = plain

--- a/tests/int_attrs.c
+++ b/tests/int_attrs.c
@@ -1,0 +1,59 @@
+#include "test.h"
+
+int
+main(void)
+{
+  struct Canfigger *list =
+    canfigger_parse_file(SOURCE_DIR "/int_attrs.conf", ',');
+  assert(list);
+
+  /* board = rect, 10, 20, 50, 50 */
+  assert(strcmp(list->key, "board") == 0);
+  assert(strcmp(list->value, "rect") == 0);
+  int coords[4];
+  size_t n = canfigger_get_int_attrs(list, coords, 4);
+  assert(n == 4);
+  assert(coords[0] == 10);
+  assert(coords[1] == 20);
+  assert(coords[2] == 50);
+  assert(coords[3] == 50);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* seat = pos, 100, 200 */
+  assert(strcmp(list->key, "seat") == 0);
+  int point[2];
+  n = canfigger_get_int_attrs(list, point, 2);
+  assert(n == 2);
+  assert(point[0] == 100);
+  assert(point[1] == 200);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* negative = offset, -10, -20 */
+  assert(strcmp(list->key, "negative") == 0);
+  int neg[2];
+  n = canfigger_get_int_attrs(list, neg, 2);
+  assert(n == 2);
+  assert(neg[0] == -10);
+  assert(neg[1] == -20);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* many = list, 1, 2, 3, 4, 5, 6 — max less than attribute count */
+  assert(strcmp(list->key, "many") == 0);
+  int few[3];
+  n = canfigger_get_int_attrs(list, few, 3);
+  assert(n == 3);
+  assert(few[0] == 1);
+  assert(few[1] == 2);
+  assert(few[2] == 3);
+  canfigger_free_current_key_node_advance(&list);
+
+  /* noattrs = plain — no attributes, expect 0 */
+  assert(strcmp(list->key, "noattrs") == 0);
+  int dummy[1];
+  n = canfigger_get_int_attrs(list, dummy, 1);
+  assert(n == 0);
+  canfigger_free_current_key_node_advance(&list);
+
+  assert(list == NULL);
+  return 0;
+}

--- a/tests/int_attrs.conf
+++ b/tests/int_attrs.conf
@@ -1,0 +1,5 @@
+board = rect, 10, 20, 50, 50
+seat = pos, 100, 200
+negative = offset, -10, -20
+many = list, 1, 2, 3, 4, 5, 6
+noattrs = plain

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,8 @@
 test_cases = [
   'check_version',
   'bom',
+  'double_attrs',
+  'int_attrs',
   'colons',
   'config_file',
   'dirs',


### PR DESCRIPTION
Adds compilable @snippet examples for five public API functions; @code/@endcode blocks in canfigger.h are replaced with @snippet references.